### PR TITLE
Run tests on both Windows and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 packages/
+TestResults.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ mono:
 install:
   - nuget restore HelloOwin.sln
 script:
-  - xbuild /p:Configuration=Release HelloOwin.sln
-  - mono ./packages/xunit.runner.console.*/tools/net461/xunit.console.exe ./HelloOwinTests/bin/Release/HelloOwinTests.dll
+  - msbuild /p:Configuration=Release HelloOwin.sln
+  - ./test.sh Release

--- a/HelloOwin.sln
+++ b/HelloOwin.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		ReadMe.md = ReadMe.md
 		run-client.cmd = run-client.cmd
 		run-server.cmd = run-server.cmd
+		test.sh = test.sh
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloOwinTests", "HelloOwinTests\HelloOwinTests.csproj", "{19BF71A2-89D4-4B22-B3C5-4A710376AA25}"

--- a/HelloOwinTests/HelloOwinTests.csproj
+++ b/HelloOwinTests/HelloOwinTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hello.Owin.Tests</RootNamespace>
     <AssemblyName>HelloOwinTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,28 +6,66 @@
 trigger:
 - master
 
-pool:
-  vmImage: 'windows-latest'
-
 variables:
-  solution: '**/*.sln'
+  solution: 'HelloOwin.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
-steps:
-- task: NuGetToolInstaller@0
+jobs:
+  - job: 'csharpWindows'
+    pool:
+      vmImage: 'vs2017-win2016'
+    displayName: 'C# (Windows)'
 
-- task: NuGetCommand@2
-  inputs:
-    restoreSolution: '$(solution)'
+    steps:
+      - task: NuGetToolInstaller@1
+        displayName: 'Install NuGet Tools'
 
-- task: VSBuild@1
-  inputs:
-    solution: '$(solution)'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+      - task: NuGetCommand@2
+        inputs:
+          restoreSolution: '$(solution)'
+        displayName: 'NuGet Restore'
 
-- task: VSTest@2
-  inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+      - task: VSBuild@1
+        inputs:
+          solution: '$(solution)'
+          platform: '$(buildPlatform)'
+          configuration: '$(buildConfiguration)'
+        displayName: 'Build'
+
+      - task: VSTest@2
+        inputs:
+          platform: '$(buildPlatform)'
+          configuration: '$(buildConfiguration)'
+          codeCoverageEnabled: True
+        displayName: 'Test'
+
+  - job: 'csharpLinux'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    displayName: 'C# (Linux)'
+
+    steps:
+      - task: NuGetToolInstaller@1
+        displayName: 'Install NuGet Tools'
+
+      - script: |
+          mono --version
+          msbuild /version
+          nuget --version
+          dotnet --info | grep 'Base Path'
+          ls /usr/share/dotnet/shared/Microsoft.NETCore.App/
+        displayName: 'Environment Info'
+
+      - task: NuGetCommand@2
+        inputs:
+          restoreSolution: '$(solution)'
+        displayName: 'NuGet Restore'
+
+      - script: |
+          msbuild /p:Configuration=$(buildConfiguration) $(solution)
+        displayName: 'Build'
+
+      - script: |
+          ./test.sh $(buildConfiguration)
+        displayName: 'Test'

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+BUILD_CONFIGURATION=${1?="Debug"}
+
+mono packages/xunit.runner.console.*/tools/net46/xunit.console.exe \
+    HelloOwinTests/bin/${BUILD_CONFIGURATION}/HelloOwinTests.dll \
+    -xml TestResults.xml


### PR DESCRIPTION
Run tests on both Windows and Linux

- Separate NuGet Restore step
- NuGet restore for Linux build.
- Install latest nuget version for Linux.

- tests.sh - add param to specify which build configuration to run tests against.

- Change from deprecated use of `xbuild` to using `msbuild`
