### PR TITLE
ITestOutputHelper.WriteLine

### DIFF
--- a/HelloOwinClient/HelloOwinClient.cs
+++ b/HelloOwinClient/HelloOwinClient.cs
@@ -104,7 +104,7 @@ namespace Hello.Owin.Client
             return httpMsg;
         }
 
-        public async Task<string> GetWebResponse(HttpClient httpClient, HttpRequestMessage httpMsg)
+        public static async Task<string> GetWebResponse(HttpClient httpClient, HttpRequestMessage httpMsg)
         {
             HttpResponseMessage response = await httpClient.SendAsync(httpMsg);
 
@@ -112,7 +112,7 @@ namespace Hello.Owin.Client
                 (int) response.StatusCode,
                 Enum.GetName(typeof(HttpStatusCode), response.StatusCode));
 
-            response.EnsureSuccessStatusCode(); // Throws exception if HTTP error ocurred.
+            response.EnsureSuccessStatusCode(); // Throws exception if HTTP error occurred.
 
             string responseBody = await response.Content.ReadAsStringAsync();
 

--- a/HelloOwinTests/HelloOwinTests.cs
+++ b/HelloOwinTests/HelloOwinTests.cs
@@ -6,11 +6,19 @@ using Hello.Owin.Server;
 using Microsoft.Owin.Testing;
 using Owin;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Hello.Owin.Tests
 {
     public class HelloOwinTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public HelloOwinTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         [Fact]
         public void ServerStartupTest()
         {
@@ -20,7 +28,7 @@ namespace Hello.Owin.Tests
                 app.Use<HelloMessageProcessor>();
             }))
             {
-                Console.WriteLine("Started Owin server {0}", server);
+                _testOutputHelper.WriteLine("Started Owin server {0}", server);
             }
         }
 
@@ -29,7 +37,7 @@ namespace Hello.Owin.Tests
         {
             using (TestServer server = TestServer.Create<HelloOwinServer>())
             {
-                Console.WriteLine("Started Owin server {0}", server);
+                _testOutputHelper.WriteLine("Started Owin server {0}", server);
             }
         }
 

--- a/HelloOwinTests/HelloOwinTests.cs
+++ b/HelloOwinTests/HelloOwinTests.cs
@@ -28,7 +28,7 @@ namespace Hello.Owin.Tests
                 app.Use<HelloMessageProcessor>();
             }))
             {
-                _testOutputHelper.WriteLine("Started Owin server {0}", server);
+                _testOutputHelper.WriteLine("Started Owin server {0}-{1}", server, server.GetHashCode());
             }
         }
 
@@ -37,7 +37,7 @@ namespace Hello.Owin.Tests
         {
             using (TestServer server = TestServer.Create<HelloOwinServer>())
             {
-                _testOutputHelper.WriteLine("Started Owin server {0}", server);
+                _testOutputHelper.WriteLine("Started Owin server {0}-{1}", server, server.GetHashCode());
             }
         }
 
@@ -58,15 +58,21 @@ namespace Hello.Owin.Tests
                 app.Use<HelloMessageProcessor>(serverArgs);
             }))
             {
+                _testOutputHelper.WriteLine("Started Owin server {0}-{1}", server, server.GetHashCode());
+
                 clientArgs.Address = server.HttpClient.BaseAddress.AbsoluteUri;
+
+                _testOutputHelper.WriteLine("Creating Owin client for address {0}", clientArgs.Address);
 
                 HelloOwinClient client = new HelloOwinClient(server.HttpClient);
 
                 rc = await client.Run(clientArgs)
                     .WithTimeout(TimeSpan.FromSeconds(10));
+                
+                _testOutputHelper.WriteLine($"Run finished with rc={rc}");
             }
 
-            rc.Should().Be(0, "HelloOwinClient.Run rc = {0}", rc);
+            rc.Should().Be(0, $"HelloOwinClient.Run rc = {rc}");
         }
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BUILD_CONFIGURATION=${1?="Debug"}
+BUILD_CONFIGURATION=${1:-"Debug"}
 
 mono packages/xunit.runner.console.*/tools/net46/xunit.console.exe \
     HelloOwinTests/bin/${BUILD_CONFIGURATION}/HelloOwinTests.dll \


### PR DESCRIPTION
ITestOutputHelper.WriteLine

Use `ITestOutputHelper.WriteLine` instead of `Console.WriteLine`
https://www.jetbrains.com/help/rider/Xunit.XunitTestWithConsoleOutput.html

Fix glitch in `test.sh` calls with no arguments.

Differentiate between Owin server instances.

Fix typo in comment.
