### PR TITLE
Microsoft.Owin v4.2.2

### DIFF
--- a/HelloOwinServer/HelloOwinServer.csproj
+++ b/HelloOwinServer/HelloOwinServer.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="CmdLine" Version="1.0.7.509" />
       <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
-      <PackageReference Include="Microsoft.Owin.SelfHost" Version="4.2.0" />
+      <PackageReference Include="Microsoft.Owin.SelfHost" Version="4.2.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 

--- a/HelloOwinTests/HelloOwinTests.csproj
+++ b/HelloOwinTests/HelloOwinTests.csproj
@@ -11,8 +11,8 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="Microsoft.Owin.Diagnostics" Version="4.2.0" />
-        <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.0" />
+        <PackageReference Include="Microsoft.Owin.Diagnostics" Version="4.2.2" />
+        <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
         <PackageReference Include="MSFT.ParallelExtensionsExtras" Version="1.2.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.console" Version="2.4.1" />


### PR DESCRIPTION
Microsoft.Owin v4.2.2

- Bump `Microsoft.Owin.Diagnostics` to v4.2.2
- Bump `Microsoft.Owin.SelfHost` to v4.2.2
- Bump `Microsoft.Owin.Testing` to v4.2.2