### PR TITLE
Update dotnet CI build/test matrix versions

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: [ '3.1.x', '5.0.x' ]
+        dotnet: [ '3.1.x', '6.0.x', '7.0.x' ]
         os: [ 'windows-latest' ]
     name: DotNet ${{ matrix.dotnet }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -24,3 +24,4 @@ jobs:
         run: dotnet build --configuration Release
       - name: Test with dotnet
         run: dotnet test --configuration Release
+


### PR DESCRIPTION
- Add dotnet 6.0.x (LTS) and 7.0.x (Latest) and remove 5.0.x (Out of support) to CI build/test matrix

  https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core