### PR TITLE
Bump xunit to v2.6.4

### DIFF
--- a/HelloOwinTests/HelloOwinTests.csproj
+++ b/HelloOwinTests/HelloOwinTests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Microsoft.Owin.Diagnostics" Version="4.2.2" />
         <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
         <PackageReference Include="MSFT.ParallelExtensionsExtras" Version="1.2.0" />
-        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit" Version="2.6.4" />
         <PackageReference Include="xunit.runner.console" Version="2.6.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HelloOwinTests/HelloOwinTests.csproj
+++ b/HelloOwinTests/HelloOwinTests.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.2" />
         <PackageReference Include="MSFT.ParallelExtensionsExtras" Version="1.2.0" />
         <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="xunit.runner.console" Version="2.6.2">
+        <PackageReference Include="xunit.runner.console" Version="2.6.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Bump xunit and xunit.runner.console packages from 2.6.2 to 2.6.4

https://github.com/xunit/xunit

Bumps `xunit` from 2.6.2 to 2.6.4.
Bumps `xunit.runner.console` from 2.6.2 to 2.6.4.

- [Commits](https://github.com/xunit/xunit/compare/2.6.2...2.6.4)
    
