### PR TITLE
Run dotnet build on Ubuntu Linux and MacOS as well as Windows

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet: [ '3.1.x', '6.0.x', '7.0.x' ]
-        os: [ 'windows-latest' ]
+        os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
     name: DotNet ${{ matrix.dotnet }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,4 +24,3 @@ jobs:
         run: dotnet build --configuration Release
       - name: Test with dotnet
         run: dotnet test --configuration Release
-


### PR DESCRIPTION
Run the dotnet core build on Ubuntu Linux and MacOS as well as Windows.

Fixes #90 