### PR TITLE
Default branch name - main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 17 * * 4'
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,7 +7,7 @@ name: Lint Code Base
 on:
   push:
     branches-ignore:
-      - "master"
+      - main
 
 jobs:
   build:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
 trigger:
-  - master
+  - main
 
 variables:
   solution: "HelloOwin.sln"


### PR DESCRIPTION
The default branch name in the repo was renamed from `master` to `main`.

These are a few outstanding references to the old name in GitHub and/or Azure DevOps pipeline jobs.